### PR TITLE
new AddWithRetention function

### DIFF
--- a/client.go
+++ b/client.go
@@ -225,6 +225,19 @@ func (client *Client) Add(key string, timestamp int64, value float64) (err error
 	return err
 }
 
+// addwithduration - append a new value to the series with a duration
+// args:
+// key - time series key name
+// timestamp - time of value
+// value - value
+// duration - value
+func (client *Client) AddWithRetention(key string, timestamp int64, value float64, duration int64) (err error) {
+	conn := client.Pool.Get()
+	defer conn.Close()
+	_, err = conn.Do("TS.ADD", key, timestamp, floatToStr(value), "RETENTION", strconv.FormatInt(duration, 10))
+	return err
+}
+
 type DataPoint struct {
 	Timestamp int64
 	Value     float64
@@ -290,7 +303,7 @@ func (client *Client) AggRange(key string, fromTimestamp int64, toTimestamp int6
 	bucketSizeSec int) (dataPoints []DataPoint, err error) {
 	conn := client.Pool.Get()
 	defer conn.Close()
-	info, err := conn.Do("TS.RANGE", key, strconv.FormatInt(fromTimestamp, 10), strconv.FormatInt(toTimestamp, 10), 
+	info, err := conn.Do("TS.RANGE", key, strconv.FormatInt(fromTimestamp, 10), strconv.FormatInt(toTimestamp, 10),
 		"AGGREGATION", aggType.String(), bucketSizeSec)
 	if err != nil {
 		return nil, err

--- a/client_test.go
+++ b/client_test.go
@@ -15,7 +15,7 @@ var tooShortDuration, _ = time.ParseDuration("10ms")
 func TestCreateKey(t *testing.T) {
 	err := client.CreateKey("test_CreateKey", defaultDuration)
 	assert.Equal(t, nil, err)
-	
+
 	err = client.CreateKey("test_CreateKey", tooShortDuration)
 	assert.NotNil(t, err)
 }
@@ -81,6 +81,19 @@ func TestAdd(t *testing.T) {
 	assert.Equal(t, now, info.LastTimestamp)
 }
 
+func TestAddWithRetention(t *testing.T) {
+	// There is no way I know of yet that allows me to query the retention for a single datapoint
+	// this test should probably be improved
+	key := "test_ADDWITHRETENTION"
+	now := time.Now().Unix()
+	PI := 3.14159265359
+	client.CreateKey(key, defaultDuration)
+	err := client.AddWithRetention(key, now, PI, 2112)
+	assert.Equal(t, nil, err)
+	info, _ := client.Info(key)
+	assert.Equal(t, now, info.LastTimestamp)
+}
+
 func TestClient_Range(t *testing.T) {
 	key := "test_Range"
 	client.CreateKey(key, defaultDuration)
@@ -105,8 +118,8 @@ func TestClient_Range(t *testing.T) {
 	assert.Equal(t, nil, err)
 	expected = []DataPoint{}
 	assert.Equal(t, expected, dataPoints)
-	
-	_, err = client.Range(key + "1", now-1, now)
+
+	_, err = client.Range(key+"1", now-1, now)
 	assert.NotNil(t, err)
 }
 
@@ -123,7 +136,7 @@ func TestClient_AggRange(t *testing.T) {
 	dataPoints, err := client.AggRange(key, now-60, now, CountAggregation, 10)
 	assert.Equal(t, nil, err)
 	assert.Equal(t, 2.0, dataPoints[0].Value)
-	
+
 	_, err = client.AggRange(key+"1", now-60, now, CountAggregation, 10)
 	assert.NotNil(t, err)
 


### PR DESCRIPTION
Allow the client to specifically set the RETENTION for a time series entry on the TS.ADD 