### PR TITLE
TS.ADD refactor on go client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,13 @@
 .project
 
 vendor/
+
+# OS generated files #
+######################
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db


### PR DESCRIPTION
fixes #41 and #40. Overall description
- [add] hability to add with auto timestamp
- [add] included default create options for TS. 
- [fix] deprecated AddWithRetention in favor of AddWithOptions. 
- [fix] deprecated CreateKey in favor of CreateKeyWithOptions