### PR TITLE
add MultiRangeWithOptions. deprecate AggMultiRange.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+coverage.txt
 
 .idea
 .project

--- a/README.md
+++ b/README.md
@@ -7,10 +7,15 @@
 
 # redis-timeseries-go
 
-Go client for RedisTimeSeries (https://github.com/RedisLabsModules/redis-timeseries)
+Go client for RedisTimeSeries (https://github.com/RedisLabsModules/redis-timeseries), based on redigo.
 
 Client and ConnPool based on the work of dvirsky and mnunberg on https://github.com/RediSearch/redisearch-go
 
+## Installing
+
+```sh
+$ go get github.com/RedisTimeSeries/redistimeseries-go
+```
 
 ## Running tests
 


### PR DESCRIPTION
fixes #44 #45.  

- [add] added MultiRangeWithOptions method (support COUNT and WITHLABELS). 
- [add] created MultiRangeOptions. 
- [deprecates] deprecates AggMultiRange ( added info on godoc comment ) in favor of MultiRangeWithOptions since it does not support `COUNT` and `WITHLABELS` and forces the usage of aggregations.