### PR TITLE
Apply linter to project and run linter on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,12 @@ jobs:
       - checkout
       - run: make checkfmt
       - run: make get
+      - run:
+          name: "Validate lint"
+            command: |
+              curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(go env GOPATH)/bin v1.29.0
+              make lint
+      - run: make test
       - run: make coverage
       - run: bash <(curl -s https://codecov.io/bash) -t ${CODECOV_TOKEN}
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,9 +15,9 @@ jobs:
       - run: make get
       - run:
           name: "Validate lint"
-            command: |
-              curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(go env GOPATH)/bin v1.29.0
-              make lint
+          command: |
+            curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(go env GOPATH)/bin v1.29.0
+            make lint
       - run: make test
       - run: make coverage
       - run: bash <(curl -s https://codecov.io/bash) -t ${CODECOV_TOKEN}

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,8 @@ checkfmt:
 	fi && \
 	exit $$EXIT_CODE
 
+lint:
+	@golangci-lint run
 get:
 	$(GOGET) -t -v ./...
 

--- a/client_test.go
+++ b/client_test.go
@@ -48,28 +48,30 @@ func (client *Client) FlushAll() (err error) {
 }
 
 func TestCreateKey(t *testing.T) {
-	client.FlushAll()
-	err := client.CreateKey("test_CreateKey", defaultDuration)
-	assert.Equal(t, nil, err)
+	err := client.FlushAll()
+	assert.Nil(t, err)
+	err = client.CreateKey("test_CreateKey", defaultDuration)
+	assert.Nil(t, err)
 
 	labels := map[string]string{
 		"cpu":     "cpu1",
 		"country": "IT",
 	}
 	err = client.CreateKeyWithOptions("test_CreateKeyLabels", CreateOptions{RetentionMSecs: defaultDuration, Labels: labels})
-	assert.Equal(t, nil, err)
+	assert.Nil(t, err)
 
 	err = client.CreateKey("test_CreateKey", tooShortDuration)
 	assert.NotNil(t, err)
 }
 
 func TestAlterKey(t *testing.T) {
-	client.FlushAll()
+	err := client.FlushAll()
+	assert.Nil(t, err)
 	labels := map[string]string{
 		"cpu":     "cpu1",
 		"country": "IT",
 	}
-	err := client.AlterKeyWithOptions("test_AlterKey", CreateOptions{RetentionMSecs: defaultDuration, Labels: labels})
+	err = client.AlterKeyWithOptions("test_AlterKey", CreateOptions{RetentionMSecs: defaultDuration, Labels: labels})
 	assert.NotNil(t, err)
 	err = client.CreateKeyWithOptions("test_AlterKey", CreateOptions{RetentionMSecs: defaultDuration, Labels: labels})
 	assert.Nil(t, err)
@@ -78,34 +80,39 @@ func TestAlterKey(t *testing.T) {
 }
 
 func TestQueryIndex(t *testing.T) {
-	client.FlushAll()
+	err := client.FlushAll()
+	assert.Nil(t, err)
 	labels := map[string]string{
 		"sensor_id": "3",
 		"area_id":   "32",
 	}
 
-	_, err := client.AddWithOptions("test_QueryIndex", 1, 18.7, CreateOptions{Uncompressed: false, Labels: labels})
+	_, err = client.AddWithOptions("test_QueryIndex", 1, 18.7, CreateOptions{Uncompressed: false, Labels: labels})
 	assert.Nil(t, err)
 	keys, err := client.QueryIndex("sensor_id=3", "area_id=32")
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(keys))
 	assert.Equal(t, "test_QueryIndex", keys[0])
 	keys, err = client.QueryIndex("sensor_id=2")
+	assert.Nil(t, err)
 	assert.Equal(t, 0, len(keys))
 }
 
 func TestCreateUncompressedKey(t *testing.T) {
-	client.FlushAll()
+	err := client.FlushAll()
+	assert.Nil(t, err)
 	compressedKey := "test_Compressed"
 	uncompressedKey := "test_Uncompressed"
-	err := client.CreateKeyWithOptions(compressedKey, CreateOptions{Uncompressed: false})
-	assert.Equal(t, nil, err)
+	err = client.CreateKeyWithOptions(compressedKey, CreateOptions{Uncompressed: false})
+	assert.Nil(t, err)
 	err = client.CreateKeyWithOptions(uncompressedKey, CreateOptions{Uncompressed: true})
-	assert.Equal(t, nil, err)
+	assert.Nil(t, err)
 	var i int64 = 0
 	for ; i < 1000; i++ {
-		client.Add(compressedKey, i, 18.7)
-		client.Add(uncompressedKey, i, 18.7)
+		_, err = client.Add(compressedKey, i, 18.7)
+		assert.Nil(t, err)
+		_, err = client.Add(uncompressedKey, i, 18.7)
+		assert.Nil(t, err)
 	}
 	CompressedInfo, _ := client.Info(compressedKey)
 	UncompressedInfo, _ := client.Info(uncompressedKey)
@@ -115,8 +122,10 @@ func TestCreateUncompressedKey(t *testing.T) {
 	compressedKey = "test_Compressed_Add"
 	uncompressedKey = "test_Uncompressed_Add"
 	for i = 0; i < 1000; i++ {
-		client.AddWithOptions(compressedKey, i, 18.7, CreateOptions{Uncompressed: false})
-		client.AddWithOptions(uncompressedKey, i, 18.7, CreateOptions{Uncompressed: true})
+		_, err = client.AddWithOptions(compressedKey, i, 18.7, CreateOptions{Uncompressed: false})
+		assert.Nil(t, err)
+		_, err = client.AddWithOptions(uncompressedKey, i, 18.7, CreateOptions{Uncompressed: true})
+		assert.Nil(t, err)
 	}
 	CompressedInfo, _ = client.Info(compressedKey)
 	UncompressedInfo, _ = client.Info(uncompressedKey)
@@ -125,17 +134,19 @@ func TestCreateUncompressedKey(t *testing.T) {
 }
 
 func TestCreateRule(t *testing.T) {
-	client.FlushAll()
+	err := client.FlushAll()
+	assert.Nil(t, err)
 	var destinationKey string
-	var err error
 	key := "test_CreateRule"
-	client.CreateKey(key, defaultDuration)
+	err = client.CreateKey(key, defaultDuration)
+	assert.Nil(t, err)
 	var found bool
 	for _, aggString := range aggToString {
 		destinationKey = string("test_CreateRule_dest" + aggString)
-		client.CreateKey(destinationKey, defaultDuration)
+		err = client.CreateKey(destinationKey, defaultDuration)
+		assert.Nil(t, err)
 		err = client.CreateRule(key, aggString, 100, destinationKey)
-		assert.Equal(t, nil, err)
+		assert.Nil(t, err)
 		info, _ := client.Info(key)
 		found = false
 		for _, rule := range info.Rules {
@@ -148,14 +159,18 @@ func TestCreateRule(t *testing.T) {
 }
 
 func TestClientInfo(t *testing.T) {
-	client.FlushAll()
+	err := client.FlushAll()
+	assert.Nil(t, err)
 	key := "test_INFO"
 	destKey := "test_INFO_dest"
-	client.CreateKey(key, defaultDuration)
-	client.CreateKey(destKey, defaultDuration)
-	client.CreateRule(key, AvgAggregation, 100, destKey)
+	err = client.CreateKey(key, defaultDuration)
+	assert.Nil(t, err)
+	err = client.CreateKey(destKey, defaultDuration)
+	assert.Nil(t, err)
+	err = client.CreateRule(key, AvgAggregation, 100, destKey)
+	assert.Nil(t, err)
 	res, err := client.Info(key)
-	assert.Equal(t, nil, err)
+	assert.Nil(t, err)
 	expected := KeyInfo{ChunkCount: 1,
 		MaxSamplesPerChunk: 256, LastTimestamp: 0, RetentionTime: 3600000,
 		Rules:  []Rule{{DestKey: destKey, BucketSizeSec: 100, AggType: AvgAggregation}},
@@ -165,14 +180,18 @@ func TestClientInfo(t *testing.T) {
 }
 
 func TestDeleteRule(t *testing.T) {
-	client.FlushAll()
+	err := client.FlushAll()
+	assert.Nil(t, err)
 	key := "test_DELETE"
 	destKey := "test_DELETE_dest"
-	client.CreateKey(key, defaultDuration)
-	client.CreateKey(destKey, defaultDuration)
-	client.CreateRule(key, AvgAggregation, 100, destKey)
-	err := client.DeleteRule(key, destKey)
-	assert.Equal(t, nil, err)
+	err = client.CreateKey(key, defaultDuration)
+	assert.Nil(t, err)
+	err = client.CreateKey(destKey, defaultDuration)
+	assert.Nil(t, err)
+	err = client.CreateRule(key, AvgAggregation, 100, destKey)
+	assert.Nil(t, err)
+	err = client.DeleteRule(key, destKey)
+	assert.Nil(t, err)
 	info, _ := client.Info(key)
 	assert.Equal(t, 0, len(info.Rules))
 	err = client.DeleteRule(key, destKey)
@@ -180,13 +199,15 @@ func TestDeleteRule(t *testing.T) {
 }
 
 func TestAdd(t *testing.T) {
-	client.FlushAll()
+	err := client.FlushAll()
+	assert.Nil(t, err)
 	key := "test_ADD"
 	now := time.Now().Unix()
 	PI := 3.14159265359
-	client.CreateKey(key, defaultDuration)
+	err = client.CreateKey(key, defaultDuration)
+	assert.Nil(t, err)
 	storedTimestamp, err := client.Add(key, now, PI)
-	assert.Equal(t, nil, err)
+	assert.Nil(t, err)
 	assert.Equal(t, now, storedTimestamp)
 	info, _ := client.Info(key)
 	assert.Equal(t, now, info.LastTimestamp)
@@ -205,21 +226,25 @@ func TestAdd(t *testing.T) {
 }
 
 func TestAddWithRetention(t *testing.T) {
-	client.FlushAll()
+	err := client.FlushAll()
+	assert.Nil(t, err)
 	key := "test_ADDWITHRETENTION"
 	now := time.Now().Unix()
 	PI := 3.14159265359
-	client.CreateKey(key, defaultDuration)
-	_, err := client.AddWithRetention(key, now, PI, 1000000)
-	assert.Equal(t, nil, err)
+	err = client.CreateKey(key, defaultDuration)
+	assert.Nil(t, err)
+	_, err = client.AddWithRetention(key, now, PI, 1000000)
+	assert.Nil(t, err)
 	info, _ := client.Info(key)
 	assert.Equal(t, now, info.LastTimestamp)
 }
 
 func TestClient_AggRange(t *testing.T) {
-	client.FlushAll()
+	err := client.FlushAll()
+	assert.Nil(t, err)
 	key := "test_aggRange"
-	client.CreateKey(key, defaultDuration)
+	err = client.CreateKey(key, defaultDuration)
+	assert.Nil(t, err)
 	ts1 := int64(1)
 	ts2 := int64(10)
 
@@ -228,22 +253,25 @@ func TestClient_AggRange(t *testing.T) {
 
 	expectedResponse := []DataPoint{{int64(0), 1.0}, {int64(10), 1.0}}
 
-	client.Add(key, ts1, value1)
-	client.Add(key, ts2, value2)
+	_, err = client.Add(key, ts1, value1)
+	assert.Nil(t, err)
+	_, err = client.Add(key, ts2, value2)
+	assert.Nil(t, err)
 
 	dataPoints, err := client.AggRange(key, ts1, ts2, CountAggregation, 10)
-	assert.Equal(t, nil, err)
+	assert.Nil(t, err)
 	assert.Equal(t, expectedResponse, dataPoints)
 
 	// ensure zero-based index produces same response
 	dataPointsZeroBased, err := client.AggRange(key, 0, ts2, CountAggregation, 10)
-	assert.Equal(t, nil, err)
+	assert.Nil(t, err)
 	assert.Equal(t, dataPoints, dataPointsZeroBased)
 
 }
 
 func TestClient_AggMultiRange(t *testing.T) {
-	client.FlushAll()
+	err := client.FlushAll()
+	assert.Nil(t, err)
 	key := "test_aggMultiRange1"
 	labels := map[string]string{
 		"cpu":     "cpu1",
@@ -251,20 +279,24 @@ func TestClient_AggMultiRange(t *testing.T) {
 	}
 	ts1 := int64(1)
 	ts2 := int64(2)
-	client.AddWithOptions(key, ts1, 5.0, CreateOptions{RetentionMSecs: defaultDuration, Labels: labels})
-	client.AddWithOptions(key, ts2, 6.0, CreateOptions{RetentionMSecs: defaultDuration, Labels: labels})
-
+	_, err = client.AddWithOptions(key, ts1, 5.0, CreateOptions{RetentionMSecs: defaultDuration, Labels: labels})
+	assert.Nil(t, err)
+	_, err = client.AddWithOptions(key, ts2, 6.0, CreateOptions{RetentionMSecs: defaultDuration, Labels: labels})
+	assert.Nil(t, err)
 	key2 := "test_aggMultiRange2"
 	labels2 := map[string]string{
 		"cpu":     "cpu2",
 		"country": "US",
 	}
-	client.CreateKeyWithOptions(key2, CreateOptions{RetentionMSecs: defaultDuration, Labels: labels2})
-	client.AddWithOptions(key2, ts1, 4.0, CreateOptions{})
-	client.Add(key2, ts2, 8.0)
+	err = client.CreateKeyWithOptions(key2, CreateOptions{RetentionMSecs: defaultDuration, Labels: labels2})
+	assert.Nil(t, err)
+	_, err = client.AddWithOptions(key2, ts1, 4.0, CreateOptions{})
+	assert.Nil(t, err)
+	_, err = client.Add(key2, ts2, 8.0)
+	assert.Nil(t, err)
 
 	ranges, err := client.AggMultiRange(ts1, ts2, CountAggregation, 10, "country=US")
-	assert.Equal(t, nil, err)
+	assert.Nil(t, err)
 	assert.Equal(t, 2, len(ranges))
 	assert.Equal(t, 2.0, ranges[0].DataPoints[0].Value)
 
@@ -274,7 +306,8 @@ func TestClient_AggMultiRange(t *testing.T) {
 }
 
 func TestClient_AggMultiRangeWithOptions(t *testing.T) {
-	client.FlushAll()
+	err := client.FlushAll()
+	assert.Nil(t, err)
 	key := "test_aggMultiRange1"
 	labels := map[string]string{
 		"cpu":     "cpu1",
@@ -282,30 +315,36 @@ func TestClient_AggMultiRangeWithOptions(t *testing.T) {
 	}
 	ts1 := int64(1)
 	ts2 := int64(2)
-	client.AddWithOptions(key, ts1, 1, CreateOptions{RetentionMSecs: defaultDuration, Labels: labels})
-	client.AddWithOptions(key, ts2, 2, CreateOptions{RetentionMSecs: defaultDuration, Labels: labels})
+	_, err = client.AddWithOptions(key, ts1, 1, CreateOptions{RetentionMSecs: defaultDuration, Labels: labels})
+	assert.Nil(t, err)
+	_, err = client.AddWithOptions(key, ts2, 2, CreateOptions{RetentionMSecs: defaultDuration, Labels: labels})
+	assert.Nil(t, err)
 
 	key2 := "test_aggMultiRange2"
 	labels2 := map[string]string{
 		"cpu":     "cpu2",
 		"country": "US",
 	}
-	client.CreateKeyWithOptions(key2, CreateOptions{RetentionMSecs: defaultDuration, Labels: labels2})
-	client.AddWithOptions(key2, ts1, 1, CreateOptions{})
-	client.Add(key2, ts2, 2)
+	err = client.CreateKeyWithOptions(key2, CreateOptions{RetentionMSecs: defaultDuration, Labels: labels2})
+	assert.Nil(t, err)
+	_, err = client.AddWithOptions(key2, ts1, 1, CreateOptions{})
+	assert.Nil(t, err)
+	_, err = client.Add(key2, ts2, 2)
+	assert.Nil(t, err)
 
 	ranges, err := client.MultiRangeWithOptions(ts1, ts2, DefaultMultiRangeOptions, "country=US")
-	assert.Equal(t, nil, err)
+	assert.Nil(t, err)
 	assert.Equal(t, 2, len(ranges))
 }
 
 func TestClient_Get(t *testing.T) {
-	client.FlushAll()
+	err := client.FlushAll()
+	assert.Nil(t, err)
 	keyWithData := "test_TestClient_Get_keyWithData"
 	keyEmpty := "test_TestClient_Get_Empty_Key"
 	noKey := "test_TestClient_Get_dontexist"
 
-	err := client.CreateKeyWithOptions(keyEmpty, DefaultCreateOptions)
+	err = client.CreateKeyWithOptions(keyEmpty, DefaultCreateOptions)
 	if err != nil {
 		t.Errorf("TestClient_Get CreateKeyWithOptions() error = %v", err)
 		return
@@ -356,7 +395,8 @@ func TestClient_Get(t *testing.T) {
 }
 
 func TestClient_MultiGet(t *testing.T) {
-	client.FlushAll()
+	err := client.FlushAll()
+	assert.Nil(t, err)
 	key1 := "test_TestClient_MultiGet_key1"
 	key2 := "test_TestClient_MultiGet_key2"
 	labels1 := map[string]string{
@@ -368,20 +408,17 @@ func TestClient_MultiGet(t *testing.T) {
 		"country": "UK",
 	}
 
-	_, err := client.AddWithOptions(key1, 1, 5.0, CreateOptions{Labels: labels1})
+	_, err = client.AddWithOptions(key1, 1, 5.0, CreateOptions{Labels: labels1})
 	if err != nil {
 		t.Errorf("TestClient_MultiGet Add() error = %v", err)
 		return
 	}
 	_, err = client.Add(key1, 2, 15.0)
+	assert.Nil(t, err)
 	_, err = client.Add(key1, 3, 15.0)
-
+	assert.Nil(t, err)
 	_, err = client.AddWithOptions(key2, 1, 5.0, CreateOptions{Labels: labels2})
-
-	if err != nil {
-		t.Errorf("TestClient_MultiGet Add() error = %v", err)
-		return
-	}
+	assert.Nil(t, err)
 
 	type fields struct {
 		Pool ConnPool
@@ -418,7 +455,8 @@ func TestClient_MultiGet(t *testing.T) {
 }
 
 func TestClient_MultiGetWithOptions(t *testing.T) {
-	client.FlushAll()
+	err := client.FlushAll()
+	assert.Nil(t, err)
 	key1 := "test_TestClient_MultiGet_key1"
 	key2 := "test_TestClient_MultiGet_key2"
 	labels1 := map[string]string{
@@ -430,20 +468,14 @@ func TestClient_MultiGetWithOptions(t *testing.T) {
 		"country": "UK",
 	}
 
-	_, err := client.AddWithOptions(key1, 1, 5.0, CreateOptions{Labels: labels1})
-	if err != nil {
-		t.Errorf("TestClient_MultiGetWithOptions Add() error = %v", err)
-		return
-	}
+	_, err = client.AddWithOptions(key1, 1, 5.0, CreateOptions{Labels: labels1})
+	assert.Nil(t, err)
 	_, err = client.Add(key1, 2, 15.0)
+	assert.Nil(t, err)
 	_, err = client.Add(key1, 3, 15.0)
-
+	assert.Nil(t, err)
 	_, err = client.AddWithOptions(key2, 1, 5.0, CreateOptions{Labels: labels2})
-
-	if err != nil {
-		t.Errorf("TestClient_MultiGetWithOptions Add() error = %v", err)
-		return
-	}
+	assert.Nil(t, err)
 
 	type fields struct {
 		Pool ConnPool
@@ -480,15 +512,19 @@ func TestClient_MultiGetWithOptions(t *testing.T) {
 }
 
 func TestClient_Range(t *testing.T) {
-	client.FlushAll()
+	err := client.FlushAll()
+	assert.Nil(t, err)
 	key1 := "TestClient_Range_key1"
 	key2 := "TestClient_Range_key2"
-	client.CreateKeyWithOptions(key1, DefaultCreateOptions)
-	client.CreateKeyWithOptions(key2, DefaultCreateOptions)
+	err = client.CreateKeyWithOptions(key1, DefaultCreateOptions)
+	assert.Nil(t, err)
+	err = client.CreateKeyWithOptions(key2, DefaultCreateOptions)
+	assert.Nil(t, err)
 
-	client.Add(key1, 1, 5)
-	client.Add(key1, 2, 10)
-
+	_, err = client.Add(key1, 1, 5)
+	assert.Nil(t, err)
+	_, err = client.Add(key1, 2, 10)
+	assert.Nil(t, err)
 	type fields struct {
 		Pool ConnPool
 		Name string
@@ -541,7 +577,8 @@ func TestNewClientFromPool(t *testing.T) {
 	assert.Nil(t, err2)
 }
 func TestIncrDecrBy(t *testing.T) {
-	client.FlushAll()
+	err := client.FlushAll()
+	assert.Nil(t, err)
 	labels := map[string]string{
 		"sensor_id": "3",
 		"area_id":   "32",
@@ -558,10 +595,12 @@ func TestIncrDecrBy(t *testing.T) {
 }
 
 func TestMultiAdd(t *testing.T) {
-	client.FlushAll()
+	err := client.FlushAll()
+	assert.Nil(t, err)
 
 	currentTimestamp := time.Now().UnixNano() / 1e6
-	_, err := client.AddWithOptions("test:MultiAdd", currentTimestamp, 18.7, CreateOptions{Uncompressed: false})
+	_, err = client.AddWithOptions("test:MultiAdd", currentTimestamp, 18.7, CreateOptions{Uncompressed: false})
+	assert.Nil(t, err)
 	values, err := client.MultiAdd(Sample{Key: "test:MultiAdd", DataPoint: DataPoint{Timestamp: currentTimestamp + 1, Value: 14}},
 		Sample{Key: "test:MultiAdd", DataPoint: DataPoint{Timestamp: currentTimestamp + 2, Value: 15}})
 	assert.Nil(t, err)
@@ -571,6 +610,7 @@ func TestMultiAdd(t *testing.T) {
 
 	values, err = client.MultiAdd(Sample{Key: "test:MultiAdd", DataPoint: DataPoint{Timestamp: currentTimestamp + 3, Value: 14}},
 		Sample{Key: "test:MultiAdd:notExit", DataPoint: DataPoint{Timestamp: currentTimestamp + 4, Value: 14}})
+	assert.Nil(t, err)
 	assert.Equal(t, 2, len(values))
 	assert.Equal(t, currentTimestamp+3, values[0])
 	v, ok := values[1].(error)
@@ -583,15 +623,20 @@ func TestMultiAdd(t *testing.T) {
 }
 
 func TestClient_ReverseRangeWithOptions(t *testing.T) {
-
-	client.FlushAll()
+	err := client.FlushAll()
+	assert.Nil(t, err)
 	key1 := "TestClient_RevRange_key1"
 	key2 := "TestClient_RevRange_key2"
-	client.CreateKeyWithOptions(key1, DefaultCreateOptions)
-	client.CreateKeyWithOptions(key2, DefaultCreateOptions)
+	err = client.CreateKeyWithOptions(key1, DefaultCreateOptions)
+	assert.Nil(t, err)
+	err = client.CreateKeyWithOptions(key2, DefaultCreateOptions)
+	assert.Nil(t, err)
 
-	client.Add(key1, 1, 5)
-	client.Add(key1, 2, 10)
+	_, err = client.Add(key1, 1, 5)
+	assert.Nil(t, err)
+
+	_, err = client.Add(key1, 2, 10)
+	assert.Nil(t, err)
 
 	type fields struct {
 		Pool ConnPool
@@ -634,15 +679,19 @@ func TestClient_ReverseRangeWithOptions(t *testing.T) {
 }
 
 func TestClient_RangeWithOptions(t *testing.T) {
-
-	client.FlushAll()
+	err := client.FlushAll()
+	assert.Nil(t, err)
 	key1 := "TestClient_RangeWithOptions_key1"
 	key2 := "TestClient_RangeWithOptions_key2"
-	client.CreateKeyWithOptions(key1, DefaultCreateOptions)
-	client.CreateKeyWithOptions(key2, DefaultCreateOptions)
+	err = client.CreateKeyWithOptions(key1, DefaultCreateOptions)
+	assert.Nil(t, err)
+	err = client.CreateKeyWithOptions(key2, DefaultCreateOptions)
+	assert.Nil(t, err)
 
-	client.Add(key1, 1, 5)
-	client.Add(key1, 2, 10)
+	_, err = client.Add(key1, 1, 5)
+	assert.Nil(t, err)
+	_, err = client.Add(key1, 2, 10)
+	assert.Nil(t, err)
 
 	type fields struct {
 		Pool ConnPool
@@ -685,7 +734,8 @@ func TestClient_RangeWithOptions(t *testing.T) {
 }
 
 func TestClient_MultiReverseRangeWithOptions(t *testing.T) {
-	client.FlushAll()
+	err := client.FlushAll()
+	assert.Nil(t, err)
 	key1 := "test_TestClient_MultiReverseRangeWithOptions_key1"
 	key2 := "test_TestClient_MultiReverseRangeWithOptions_key2"
 	labels1 := map[string]string{
@@ -697,19 +747,13 @@ func TestClient_MultiReverseRangeWithOptions(t *testing.T) {
 		"country": "UK",
 	}
 
-	_, err := client.AddWithOptions(key1, 1, 5.0, CreateOptions{Labels: labels1})
-	if err != nil {
-		t.Errorf("TestClient_MultiReverseRangeWithOptions Add() error = %v", err)
-		return
-	}
+	_, err = client.AddWithOptions(key1, 1, 5.0, CreateOptions{Labels: labels1})
+	assert.Nil(t, err)
 	_, err = client.Add(key1, 2, 15.0)
-
+	assert.Nil(t, err)
 	_, err = client.AddWithOptions(key2, 1, 5.0, CreateOptions{Labels: labels2})
+	assert.Nil(t, err)
 
-	if err != nil {
-		t.Errorf("TestClient_MultiReverseRangeWithOptions Add() error = %v", err)
-		return
-	}
 	type fields struct {
 		Pool ConnPool
 		Name string

--- a/common.go
+++ b/common.go
@@ -86,7 +86,7 @@ type Range struct {
 // Serialize options to args
 func (options *CreateOptions) Serialize(args []interface{}) (result []interface{}, err error) {
 	result = args
-	if options.Uncompressed == true {
+	if options.Uncompressed {
 		result = append(result, "UNCOMPRESSED")
 	}
 	if options.RetentionMSecs > 0 {

--- a/example_client_test.go
+++ b/example_client_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 // exemplifies the NewClientFromPool function
+//nolint:errcheck
 func ExampleNewClientFromPool() {
 	host := "localhost:6379"
 	password := ""
@@ -22,6 +23,7 @@ func ExampleNewClientFromPool() {
 }
 
 // Exemplifies the usage of RangeWithOptions function
+// nolint:errcheck
 func ExampleClient_RangeWithOptions() {
 	host := "localhost:6379"
 	password := ""
@@ -34,11 +36,12 @@ func ExampleClient_RangeWithOptions() {
 	}
 
 	datapoints, _ := client.RangeWithOptions("ts", 0, 1000, redistimeseries.DefaultRangeOptions)
-	fmt.Println(fmt.Sprintf("Datapoints: %v", datapoints))
+	fmt.Printf("Datapoints: %v\n", datapoints)
 	// Output:
 	// Datapoints: [{1 1} {2 2} {3 3} {4 4} {5 5} {6 6} {7 7} {8 8} {9 9}]
 }
 
+// nolint
 // Exemplifies the usage of ReverseRangeWithOptions function
 func ExampleClient_ReverseRangeWithOptions() {
 	host := "localhost:6379"
@@ -52,11 +55,12 @@ func ExampleClient_ReverseRangeWithOptions() {
 	}
 
 	datapoints, _ := client.ReverseRangeWithOptions("ts", 0, 1000, redistimeseries.DefaultRangeOptions)
-	fmt.Println(fmt.Sprintf("Datapoints: %v", datapoints))
+	fmt.Printf("Datapoints: %v\n", datapoints)
 	// Output:
 	// Datapoints: [{9 9} {8 8} {7 7} {6 6} {5 5} {4 4} {3 3} {2 2} {1 1}]
 }
 
+// nolint
 // Exemplifies the usage of MultiRangeWithOptions function.
 func ExampleClient_MultiRangeWithOptions() {
 	host := "localhost:6379"
@@ -82,12 +86,13 @@ func ExampleClient_MultiRangeWithOptions() {
 
 	ranges, _ := client.MultiRangeWithOptions(1, 10, redistimeseries.DefaultMultiRangeOptions, "az=us-east-1")
 
-	fmt.Println(fmt.Sprintf("Ranges: %v", ranges))
+	fmt.Printf("Ranges: %v\n", ranges)
 	// Output:
 	// Ranges: [{time-serie-1 map[] [{2 1} {4 2}]} {time-serie-2 map[] [{1 5} {4 10}]}]
 }
 
 // Exemplifies the usage of MultiReverseRangeWithOptions function.
+// nolint:errcheck
 func ExampleClient_MultiReverseRangeWithOptions() {
 	host := "localhost:6379"
 	password := ""
@@ -112,11 +117,12 @@ func ExampleClient_MultiReverseRangeWithOptions() {
 
 	ranges, _ := client.MultiReverseRangeWithOptions(1, 10, redistimeseries.DefaultMultiRangeOptions, "az=us-east-1")
 
-	fmt.Println(fmt.Sprintf("Ranges: %v", ranges))
+	fmt.Printf("Ranges: %v\n", ranges)
 	// Output:
 	// Ranges: [{time-serie-1 map[] [{4 2} {2 1}]} {time-serie-2 map[] [{4 10} {1 5}]}]
 }
 
+//nolint:errcheck
 // Exemplifies the usage of MultiGetWithOptions function while using the default MultiGetOptions and while using user defined MultiGetOptions.
 func ExampleClient_MultiGetWithOptions() {
 	host := "localhost:6379"
@@ -144,8 +150,8 @@ func ExampleClient_MultiGetWithOptions() {
 
 	rangesWithLabels, _ := client.MultiGetWithOptions(*redistimeseries.NewMultiGetOptions().SetWithLabels(true), "az=us-east-1")
 
-	fmt.Println(fmt.Sprintf("Ranges: %v", ranges))
-	fmt.Println(fmt.Sprintf("Ranges with labels: %v", rangesWithLabels))
+	fmt.Printf("Ranges: %v\n", ranges)
+	fmt.Printf("Ranges with labels: %v\n", rangesWithLabels)
 
 	// Output:
 	// Ranges: [{time-serie-1 map[] [{4 2}]} {time-serie-2 map[] [{4 10}]}]
@@ -185,9 +191,9 @@ func ExampleClient_MultiAdd() {
 		{"timeserie-1", redistimeseries.DataPoint{2, 40.5}},
 		{"timeserie-2", redistimeseries.DataPoint{1, 60.5}},
 	}
-	timestamps, err := client.MultiAdd(datapoints...)
+	timestamps, _ := client.MultiAdd(datapoints...)
 
-	fmt.Println(fmt.Sprintf("Example adding multiple datapoints to multiple series. Added timestamps: %v", timestamps))
+	fmt.Printf("Example adding multiple datapoints to multiple series. Added timestamps: %v\n", timestamps)
 
 	// Adding multiple datapoints to the same serie
 	datapointsSameSerie := []redistimeseries.Sample{
@@ -195,9 +201,9 @@ func ExampleClient_MultiAdd() {
 		{"timeserie-1", redistimeseries.DataPoint{4, 40.5}},
 		{"timeserie-1", redistimeseries.DataPoint{5, 60.5}},
 	}
-	timestampsSameSerie, err := client.MultiAdd(datapointsSameSerie...)
+	timestampsSameSerie, _ := client.MultiAdd(datapointsSameSerie...)
 
-	fmt.Println(fmt.Sprintf("Example of adding multiple datapoints to the same serie. Added timestamps: %v", timestampsSameSerie))
+	fmt.Printf("Example of adding multiple datapoints to the same serie. Added timestamps: %v\n", timestampsSameSerie)
 
 	// Output:
 	// Example adding multiple datapoints to multiple series. Added timestamps: [1 2 1]

--- a/multiget.go
+++ b/multiget.go
@@ -23,7 +23,7 @@ func (mgetopts *MultiGetOptions) SetWithLabels(value bool) *MultiGetOptions {
 
 func createMultiGetCmdArguments(mgetOptions MultiGetOptions, filters []string) []interface{} {
 	args := []interface{}{}
-	if mgetOptions.WithLabels == true {
+	if mgetOptions.WithLabels {
 		args = append(args, "WITHLABELS")
 	}
 	args = append(args, "FILTER")

--- a/multirange.go
+++ b/multirange.go
@@ -51,7 +51,7 @@ func createMultiRangeCmdArguments(fromTimestamp int64, toTimestamp int64, mrange
 	if mrangeOptions.Count != -1 {
 		args = append(args, "COUNT", strconv.FormatInt(mrangeOptions.Count, 10))
 	}
-	if mrangeOptions.WithLabels == true {
+	if mrangeOptions.WithLabels {
 		args = append(args, "WITHLABELS")
 	}
 	args = append(args, "FILTER")

--- a/pool_test.go
+++ b/pool_test.go
@@ -21,8 +21,7 @@ func TestNewMultiHostPool(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var got *MultiHostPool
-			got = NewMultiHostPool(tt.args.hosts, tt.args.authPass)
+			got := NewMultiHostPool(tt.args.hosts, tt.args.authPass)
 			if len(got.hosts) != tt.wantPoolSize {
 				t.Errorf("NewMultiHostPool() = %v, want %v", got, tt.wantPoolSize)
 			}
@@ -43,6 +42,7 @@ func TestMultiHostPool_Close(t *testing.T) {
 		err := oneMulti.Close()
 		assert.Nil(t, err)
 		err = oneMulti.Close()
+		assert.Nil(t, err)
 		assert.NotNil(t, conn)
 		severalMulti := NewMultiHostPool([]string{host, host}, nil)
 		connMulti := severalMulti.Get()

--- a/reply_parser.go
+++ b/reply_parser.go
@@ -48,8 +48,8 @@ func ParseRules(ruleInterface interface{}, err error) (rules []Rule, retErr erro
 }
 
 func ParseInfo(result interface{}, err error) (info KeyInfo, outErr error) {
-	values, err := redis.Values(result, nil)
-	if err != nil {
+	values, outErr := redis.Values(result, err)
+	if outErr != nil {
 		return KeyInfo{}, err
 	}
 	if len(values)%2 != 0 {
@@ -57,23 +57,23 @@ func ParseInfo(result interface{}, err error) (info KeyInfo, outErr error) {
 	}
 	var key string
 	for i := 0; i < len(values); i += 2 {
-		key, err = redis.String(values[i], nil)
+		key, outErr = redis.String(values[i], nil)
 		switch key {
 		case "rules":
-			info.Rules, err = ParseRules(values[i+1], nil)
+			info.Rules, outErr = ParseRules(values[i+1], nil)
 		case "retentionTime":
-			info.RetentionTime, err = redis.Int64(values[i+1], nil)
+			info.RetentionTime, outErr = redis.Int64(values[i+1], nil)
 		case "chunkCount":
-			info.ChunkCount, err = redis.Int64(values[i+1], nil)
+			info.ChunkCount, outErr = redis.Int64(values[i+1], nil)
 		case "maxSamplesPerChunk":
-			info.MaxSamplesPerChunk, err = redis.Int64(values[i+1], nil)
+			info.MaxSamplesPerChunk, outErr = redis.Int64(values[i+1], nil)
 		case "lastTimestamp":
-			info.LastTimestamp, err = redis.Int64(values[i+1], nil)
+			info.LastTimestamp, outErr = redis.Int64(values[i+1], nil)
 		case "labels":
-			info.Labels, err = ParseLabels(values[i+1])
+			info.Labels, outErr = ParseLabels(values[i+1])
 		}
 		if err != nil {
-			return KeyInfo{}, err
+			return KeyInfo{}, outErr
 		}
 	}
 
@@ -87,7 +87,7 @@ func ParseDataPoints(info interface{}) (dataPoints []DataPoint, err error) {
 		return
 	}
 	for _, rawDataPoint := range values {
-		var dataPoint *DataPoint = nil
+		var dataPoint *DataPoint = nil //nolint:ineffassign
 		dataPoint, err = ParseDataPoint(rawDataPoint)
 		if err != nil {
 			return
@@ -219,7 +219,7 @@ func ParseRangesSingleDataPoint(info interface{}) (ranges []Range, err error) {
 		if err != nil {
 			return nil, err
 		}
-		var dataPoint *DataPoint = nil
+		var dataPoint *DataPoint = nil //nolint:ineffassign
 		dataPoint, err = ParseDataPoint(iValues[2])
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Fixes #19 
This PR applies `golangci-lint` and fixes the errors reported by the tool. Furthermore, it enforces the linter to pass CI.