### PR TITLE
Added support for CHUNK_SIZE on TS.CREATE

### DIFF
--- a/common.go
+++ b/common.go
@@ -26,16 +26,20 @@ const (
 
 var aggToString = []AggregationType{AvgAggregation, SumAggregation, MinAggregation, MaxAggregation, CountAggregation, FirstAggregation, LastAggregation, StdPAggregation, StdSAggregation, VarPAggregation, VarSAggregation}
 
+// CreateOptions are a direct mapping to the options provided when creating a new time-series
+// Check https://oss.redislabs.com/redistimeseries/1.4/commands/#tscreate for a detailed description
 type CreateOptions struct {
 	Uncompressed   bool
 	RetentionMSecs time.Duration
 	Labels         map[string]string
+	ChunkSize      int64
 }
 
 var DefaultCreateOptions = CreateOptions{
 	Uncompressed:   false,
 	RetentionMSecs: 0,
 	Labels:         map[string]string{},
+	ChunkSize:      0,
 }
 
 // Client is an interface to time series redis commands
@@ -97,6 +101,9 @@ func (options *CreateOptions) Serialize(args []interface{}) (result []interface{
 			return
 		}
 		result = append(result, "RETENTION", value)
+	}
+	if options.ChunkSize > 0 {
+		result = append(result, "CHUNK_SIZE", options.ChunkSize)
 	}
 	if len(options.Labels) > 0 {
 		result = append(result, "LABELS")

--- a/common_test.go
+++ b/common_test.go
@@ -11,6 +11,7 @@ func TestCreateOptions_Serialize(t *testing.T) {
 		Uncompressed   bool
 		RetentionMSecs time.Duration
 		Labels         map[string]string
+		ChunkSize      int64
 	}
 	type args struct {
 		args []interface{}
@@ -23,9 +24,10 @@ func TestCreateOptions_Serialize(t *testing.T) {
 		wantErr    bool
 	}{
 		// TODO: Add test cases.
-		{"emtpy", fields{false, 0, map[string]string{}}, args{[]interface{}{}}, []interface{}{}, false},
-		{"UNCOMPRESSED", fields{true, 0, map[string]string{}}, args{[]interface{}{}}, []interface{}{"UNCOMPRESSED"}, false},
-		{"RETENTION", fields{false, 1000000, map[string]string{}}, args{[]interface{}{}}, []interface{}{"RETENTION", int64(1)}, false},
+		{"emtpy", fields{false, 0, map[string]string{}, 0}, args{[]interface{}{}}, []interface{}{}, false},
+		{"UNCOMPRESSED", fields{true, 0, map[string]string{}, 0}, args{[]interface{}{}}, []interface{}{"UNCOMPRESSED"}, false},
+		{"RETENTION", fields{false, 1000000, map[string]string{}, 0}, args{[]interface{}{}}, []interface{}{"RETENTION", int64(1)}, false},
+		{"CHUNK_SIZE", fields{false, 1000000, map[string]string{}, 256}, args{[]interface{}{}}, []interface{}{"RETENTION", int64(1), "CHUNK_SIZE", int64(256)}, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -33,6 +35,7 @@ func TestCreateOptions_Serialize(t *testing.T) {
 				Uncompressed:   tt.fields.Uncompressed,
 				RetentionMSecs: tt.fields.RetentionMSecs,
 				Labels:         tt.fields.Labels,
+				ChunkSize:      tt.fields.ChunkSize,
 			}
 			gotResult, err := options.Serialize(tt.args.args)
 			if (err != nil) != tt.wantErr {


### PR DESCRIPTION
This PR enables specifying the chunk size in Bytes of a time-series.
Further reference: https://oss.redislabs.com/redistimeseries/master/commands/#tscreate
Fixes #79 