### PR TITLE
Fixed example tests due to OOO changes

### DIFF
--- a/example_client_test.go
+++ b/example_client_test.go
@@ -32,10 +32,10 @@ func ExampleClient_RangeWithOptions() {
 	}}
 	client := redistimeseries.NewClientFromPool(pool, "ts-client-1")
 	for ts := 1; ts < 10; ts++ {
-		client.Add("ts", int64(ts), float64(ts))
+		client.Add("ts-1", int64(ts), float64(ts))
 	}
 
-	datapoints, _ := client.RangeWithOptions("ts", 0, 1000, redistimeseries.DefaultRangeOptions)
+	datapoints, _ := client.RangeWithOptions("ts-1", 0, 1000, redistimeseries.DefaultRangeOptions)
 	fmt.Printf("Datapoints: %v\n", datapoints)
 	// Output:
 	// Datapoints: [{1 1} {2 2} {3 3} {4 4} {5 5} {6 6} {7 7} {8 8} {9 9}]
@@ -51,10 +51,10 @@ func ExampleClient_ReverseRangeWithOptions() {
 	}}
 	client := redistimeseries.NewClientFromPool(pool, "ts-client-1")
 	for ts := 1; ts < 10; ts++ {
-		client.Add("ts", int64(ts), float64(ts))
+		client.Add("ts-2", int64(ts), float64(ts))
 	}
 
-	datapoints, _ := client.ReverseRangeWithOptions("ts", 0, 1000, redistimeseries.DefaultRangeOptions)
+	datapoints, _ := client.ReverseRangeWithOptions("ts-2", 0, 1000, redistimeseries.DefaultRangeOptions)
 	fmt.Printf("Datapoints: %v\n", datapoints)
 	// Output:
 	// Datapoints: [{9 9} {8 8} {7 7} {6 6} {5 5} {4 4} {3 3} {2 2} {1 1}]


### PR DESCRIPTION
following CI failed build: https://app.circleci.com/pipelines/github/RedisTimeSeries/redistimeseries-go/391/workflows/4ad8d83d-5a12-4809-ad5c-d54957cc4754/jobs/770
this is happening due to `ExampleNewClientFromPool` using the same ts name ( and that examples dont delete the timeseries for simplicity/not overloading the example code), making timestamp 1 having the value 5 instead of 1.
```
GO111MODULE=on go get -t -v ./...
GO111MODULE=on go fmt ./...
GO111MODULE=on go test -count=1 -race -covermode=atomic ./...
--- FAIL: ExampleClient_RangeWithOptions (0.01s)
got:
Datapoints: [{1 5} {2 2} {3 3} {4 4} {5 5} {6 6} {7 7} {8 8} {9 9}]
want:
Datapoints: [{1 1} {2 2} {3 3} {4 4} {5 5} {6 6} {7 7} {8 8} {9 9}]
--- FAIL: ExampleClient_ReverseRangeWithOptions (0.01s)
got:
Datapoints: [{9 9} {8 8} {7 7} {6 6} {5 5} {4 4} {3 3} {2 2} {1 5}]
want:
Datapoints: [{9 9} {8 8} {7 7} {6 6} {5 5} {4 4} {3 3} {2 2} {1 1}]
FAIL
coverage: 87.8% of statements
FAIL	github.com/RedisTimeSeries/redistimeseries-go	0.310s
FAIL
make: *** [Makefile:30: test] Error 1
```
This is easily fixed by making each example use it's own ts. 