### PR TITLE
Added DeleteSerie() API that is equivalent to calling vanilla redis DEL serie.

### DIFF
--- a/client.go
+++ b/client.go
@@ -145,6 +145,16 @@ func (client *Client) AddWithRetention(key string, timestamp int64, value float6
 	return client.AddWithOptions(key, timestamp, value, options)
 }
 
+// DeleteSerie - deletes series given the time series key name. This API is sugar coating on top of redis DEL command
+// args:
+// key - time series key name
+func (client *Client) DeleteSerie(key string) (err error) {
+	conn := client.Pool.Get()
+	defer conn.Close()
+	_, err = conn.Do(DEL_CMD, key)
+	return err
+}
+
 // CreateRule - create a compaction rule
 // args:
 // sourceKey - key name for source time series

--- a/common.go
+++ b/common.go
@@ -44,6 +44,7 @@ const (
 	MGET_CMD       string = "TS.MGET"
 	INFO_CMD       string = "TS.INFO"
 	QUERYINDEX_CMD string = "TS.QUERYINDEX"
+	DEL_CMD        string = "DEL"
 )
 
 const (

--- a/example_client_test.go
+++ b/example_client_test.go
@@ -472,3 +472,26 @@ func ExampleClient_MultiAdd() {
 	// Example adding multiple datapoints to multiple series. Added timestamps: [1 2 1]
 	// Example of adding multiple datapoints to the same serie. Added timestamps: [3 4 5]
 }
+
+// exemplifies the usage of DeleteSerie function
+//nolint:errcheck
+func ExampleClient_DeleteSerie() {
+	host := "localhost:6379"
+	password := ""
+	pool := &redis.Pool{Dial: func() (redis.Conn, error) {
+		return redis.Dial("tcp", host, redis.DialPassword(password))
+	}}
+	client := redistimeseries.NewClientFromPool(pool, "ts-client-1")
+
+	// Create serie and add datapoint
+	client.Add("ts", 1, 5)
+
+	// Query the serie
+	datapoints, _ := client.RangeWithOptions("ts", 0, 1000, redistimeseries.DefaultRangeOptions)
+	fmt.Println(datapoints[0])
+	// Output: {1 5}
+
+	// Delete the serie
+	client.DeleteSerie("ts")
+
+}


### PR DESCRIPTION
cc @LeonOnRoad -- fixes #85 . 
This PR adds DeleteSerie that is basically sugar coating on the go client that calls `DEL <ts>` command.
@danni-m I don't see a reason for not adding it. It's a more verbose and straight forward API that having to call Do("DEL",ts_key)