### PR TITLE
add in IncrByAutoTs and DecrByAutoTs functions with tests

### DIFF
--- a/client.go
+++ b/client.go
@@ -373,12 +373,36 @@ func (client *Client) IncrBy(key string, timestamp int64, value float64, options
 	return redis.Int64(conn.Do(INCRBY_CMD, args...))
 }
 
+// Creates a new sample that increments the latest sample's value with an auto timestamp
+func (client *Client) IncrByAutoTs(key string, value float64, options CreateOptions) (int64, error) {
+	conn := client.Pool.Get()
+	defer conn.Close()
+
+	args, err := AddCounterArgs(key, -1, value, options)
+	if err != nil {
+		return -1, err
+	}
+	return redis.Int64(conn.Do(INCRBY_CMD, args...))
+}
+
 // Creates a new sample that decrements the latest sample's value
 func (client *Client) DecrBy(key string, timestamp int64, value float64, options CreateOptions) (int64, error) {
 	conn := client.Pool.Get()
 	defer conn.Close()
 
 	args, err := AddCounterArgs(key, timestamp, value, options)
+	if err != nil {
+		return -1, err
+	}
+	return redis.Int64(conn.Do(DECRBY_CMD, args...))
+}
+
+// Creates a new sample that decrements the latest sample's value with auto timestamp
+func (client *Client) DecrByAutoTs(key string, value float64, options CreateOptions) (int64, error) {
+	conn := client.Pool.Get()
+	defer conn.Close()
+
+	args, err := AddCounterArgs(key, -1, value, options)
 	if err != nil {
 		return -1, err
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -1,6 +1,7 @@
 package redis_timeseries_go
 
 import (
+	"log"
 	"os"
 	"reflect"
 	"testing"
@@ -723,6 +724,20 @@ func TestNewClientFromPool(t *testing.T) {
 	assert.Nil(t, err1)
 	assert.Nil(t, err2)
 }
+
+func TestIncrDecrByAutoTs(t *testing.T) {
+	tkey := "Test:IncrDecrByAutoTs"
+	err := client.FlushAll()
+	assert.Nil(t, err)
+	storedTimestamp1, _ := client.IncrByAutoTs(tkey, 101, CreateOptions{Uncompressed: false, Labels: map[string]string{}})
+	time.Sleep(1 * time.Millisecond)
+	log.Printf("YO: %+v\n", storedTimestamp1)
+	storedTimestamp2, _ := client.DecrByAutoTs(tkey, 1, CreateOptions{Uncompressed: false, Labels: map[string]string{}})
+	assert.True(t, storedTimestamp1 < storedTimestamp2)
+	datapoint, _ := client.Get(tkey)
+	assert.True(t, datapoint.Value == 100)
+}
+
 func TestIncrDecrBy(t *testing.T) {
 	err := client.FlushAll()
 	assert.Nil(t, err)


### PR DESCRIPTION
Similar to AddAutoTs we need to Incr and Decr counters without timestamps from threaded applications