### PR TITLE
Specification of dbNumber in redis connection

### DIFF
--- a/client.go
+++ b/client.go
@@ -14,11 +14,11 @@ var maxConns = 500
 // NewClient creates a new client connecting to the redis host, and using the given name as key prefix.
 // Addr can be a single host:port pair, or a comma separated list of host:port,host:port...
 // In the case of multiple hosts we create a multi-pool and select connections at random
-func NewClient(addr, name string, authPass *string) *Client {
+func NewClient(addr, name string, authPass *string, dbNumber int) *Client {
 	addrs := strings.Split(addr, ",")
 	var pool ConnPool
 	if len(addrs) == 1 {
-		pool = NewSingleHostPool(addrs[0], authPass)
+		pool = NewSingleHostPool(addrs[0], authPass, dbNumber)
 	} else {
 		pool = NewMultiHostPool(addrs, authPass)
 	}
@@ -158,9 +158,10 @@ func (client *Client) DeleteSerie(key string) (err error) {
 // DeleteRange - Delete data points for a given timeseries and interval range in the form of start and end delete timestamps.
 // Returns the total deleted datapoints.
 // args:
-//  key - time series key name
-//  fromTimestamp - start of range. You can use TimeRangeMinimum to express the minimum possible timestamp.
-//  toTimestamp - end of range. You can use TimeRangeFull or TimeRangeMaximum to express the maximum possible timestamp.
+//
+//	key - time series key name
+//	fromTimestamp - start of range. You can use TimeRangeMinimum to express the minimum possible timestamp.
+//	toTimestamp - end of range. You can use TimeRangeFull or TimeRangeMaximum to express the maximum possible timestamp.
 func (client *Client) DeleteRange(key string, fromTimestamp int64, toTimestamp int64) (totalDeletedSamples int64, err error) {
 	conn := client.Pool.Get()
 	defer conn.Close()

--- a/client_test.go
+++ b/client_test.go
@@ -57,10 +57,11 @@ func getTestConnectionDetails() (string, string) {
 func createClient() *Client {
 	host, password := getTestConnectionDetails()
 	var ptr *string = nil
+	var dbNumber = 0
 	if len(password) > 0 {
 		ptr = MakeStringPtr(password)
 	}
-	return NewClient(host, "test_client", ptr)
+	return NewClient(host, "test_client", ptr, dbNumber)
 }
 
 var client = createClient()

--- a/pool.go
+++ b/pool.go
@@ -18,9 +18,9 @@ type SingleHostPool struct {
 	*redis.Pool
 }
 
-func NewSingleHostPool(host string, authPass *string) *SingleHostPool {
+func NewSingleHostPool(host string, authPass *string, dbNumber int) *SingleHostPool {
 	ret := &redis.Pool{
-		Dial:         dialFuncWrapper(host, authPass),
+		Dial:         dialFuncWrapper(host, authPass, dbNumber),
 		TestOnBorrow: testOnBorrow,
 		MaxIdle:      maxConns,
 	}
@@ -52,7 +52,7 @@ func (p *MultiHostPool) Get() redis.Conn {
 
 	if !found {
 		pool = &redis.Pool{
-			Dial:         dialFuncWrapper(host, p.authPass),
+			Dial:         dialFuncWrapper(host, p.authPass, 0),
 			TestOnBorrow: testOnBorrow,
 			MaxIdle:      maxConns,
 		}
@@ -62,9 +62,9 @@ func (p *MultiHostPool) Get() redis.Conn {
 	return pool.Get()
 }
 
-func dialFuncWrapper(host string, authPass *string) func() (redis.Conn, error) {
+func dialFuncWrapper(host string, authPass *string, dbNumber int) func() (redis.Conn, error) {
 	return func() (redis.Conn, error) {
-		conn, err := redis.Dial("tcp", host)
+		conn, err := redis.Dial("tcp", host, redis.DialDatabase(dbNumber))
 		if err != nil {
 			return conn, err
 		}


### PR DESCRIPTION
I had the need to specify the number of database for the redis connection, by default every client connects to the 0 database, but you can specify whatever integer you want according redigo documentation.

`conn, err := redis.Dial("tcp", host)`

becomes 

`conn, err := redis.Dial("tcp", host, redis.DialDatabase(dbNumber))`

I thought this might be a useful feature for everybody so I decided to open this pull request.


