### PR TITLE
Removing LGTM

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 [![Codecov](https://codecov.io/gh/RedisTimeSeries/redistimeseries-go/branch/master/graph/badge.svg)](https://codecov.io/gh/RedisTimeSeries/redistimeseries-go)
 [![GoDoc](https://godoc.org/github.com/RedisTimeSeries/redistimeseries-go?status.svg)](https://godoc.org/github.com/RedisTimeSeries/redistimeseries-go)
 [![Go Report Card](https://goreportcard.com/badge/github.com/RedisTimeSeries/redistimeseries-go)](https://goreportcard.com/report/github.com/RedisTimeSeries/redistimeseries-go)
-[![Total alerts](https://img.shields.io/lgtm/alerts/g/RedisTimeSeries/redistimeseries-go.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/RedisTimeSeries/redistimeseries-go/alerts/)
 
 # redistimeseries-go
 [![Forum](https://img.shields.io/badge/Forum-RedisTimeSeries-blue)](https://forum.redislabs.com/c/modules/redistimeseries)
@@ -33,7 +32,7 @@ The tests expect a Redis server with the RedisTimeSeries module loaded to be ava
 ## Example Code
 
 ```go
-package main 
+package main
 
 import (
         "fmt"
@@ -51,7 +50,7 @@ func main() {
 			client.CreateRule(keyname, redistimeseries.AvgAggregation, 60, keyname+"_avg")
         }
 		// Add sample with timestamp from server time and value 100
-        // TS.ADD mytest * 100 
+        // TS.ADD mytest * 100
         _, err := client.AddAutoTs(keyname, 100)
         if err != nil {
                 fmt.Println("Error:", err)


### PR DESCRIPTION
The LGTM service is being shut off in two weeks. This pull request aims to remove all references to LGTM. Perhaps LGTM usage should be replaced with codeql, or a repository preferred tool, but IMHO that's the point of a different pull request.