### PR TITLE
feat: add new keyInfo fields in line with latest redis-timeseries return values

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -274,10 +274,15 @@ func TestClientInfo(t *testing.T) {
 	assert.Nil(t, err)
 	res, err := client.Info(key)
 	assert.Nil(t, err)
-	expected := KeyInfo{ChunkCount: 1,
-		ChunkSize: 4096, LastTimestamp: 0, RetentionTime: 3600000,
-		Rules:  []Rule{{DestKey: destKey, BucketSizeSec: 100, AggType: AvgAggregation}},
-		Labels: map[string]string{},
+	assert.Greater(t, res.MemoryUsage, int64(0))
+	res.MemoryUsage = 0
+	expected := KeyInfo{
+		TotalSamples: 0, MemoryUsage: 0,
+		ChunkCount: 1, ChunkSize: 4096, ChunkType: CompressedChunkType,
+		FirstTimestamp: 0, LastTimestamp: 0, RetentionTime: 3600000,
+		SourceKey: "",
+		Rules:     []Rule{{DestKey: destKey, BucketSizeSec: 100, AggType: AvgAggregation}},
+		Labels:    map[string]string{},
 	}
 	assert.Equal(t, expected, res)
 }

--- a/common.go
+++ b/common.go
@@ -16,6 +16,9 @@ type ReducerType string
 //go:generate stringer -type=DuplicatePolicyType
 type DuplicatePolicyType string
 
+//go:generate stringer -type=ChunkType
+type ChunkType string
+
 const (
 	SumReducer ReducerType = "SUM"
 	MinReducer ReducerType = "MIN"
@@ -66,6 +69,11 @@ const (
 	MaxDuplicatePolicy   DuplicatePolicyType = "max"   // only override if the value is higher than the existing value
 )
 
+const (
+	CompressedChunkType   ChunkType = "compressed"
+	UncompressedChunkType ChunkType = "uncompressed"
+)
+
 var aggToString = []AggregationType{AvgAggregation, SumAggregation, MinAggregation, MaxAggregation, CountAggregation, FirstAggregation, LastAggregation, StdPAggregation, StdSAggregation, VarPAggregation, VarSAggregation}
 
 // CreateOptions are a direct mapping to the options provided when creating a new time-series
@@ -103,11 +111,16 @@ type Rule struct {
 }
 
 type KeyInfo struct {
+	TotalSamples       int64
+	MemoryUsage        int64
 	ChunkCount         int64
+	ChunkType          ChunkType
 	MaxSamplesPerChunk int64 // As of RedisTimeseries >= v1.4 MaxSamplesPerChunk is deprecated in favor of ChunkSize
 	ChunkSize          int64
+	FirstTimestamp     int64
 	LastTimestamp      int64
 	RetentionTime      int64
+	SourceKey          string
 	Rules              []Rule
 	Labels             map[string]string
 	DuplicatePolicy    DuplicatePolicyType // Duplicate sample policy


### PR DESCRIPTION
## Proposed Change
This change introduces the following fields to the `client.Info(key)` response:

- totalSamples
- memoryUsage
- sourceKey
- firstTimestamp
- chunkType

which should be in line with the TS.INFO response of the latest version of the redis-timeseries module.

## Testing
- The change has been verified against docker images `redislabs/redistimeseries:latest`, as well as `redislabs/redistimeseries:1.0.0`.
- All unit tests succeed.